### PR TITLE
docs: add project wiki structure and OSS documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ npm run build
 Contributions are welcome.
 Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening issues or pull requests.
 
+## Wiki
+
+Project wiki pages are versioned in [docs/wiki](./docs/wiki/README.md) and intended for GitHub Wiki publication.
+
 ## License
 
 Licensed under the GNU Affero General Public License v3.0.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,30 @@
+# Architecture
+
+## High-Level Flow
+
+1. Connector ingestion fetches raw data into `raw_source`
+2. Normalization maps records into canonical entities/events
+3. Entity resolution clusters aliases and links nodes
+4. Baseline computation builds statistical references
+5. Typology engine runs deterministic detectors (T01-T10)
+6. Public API serves radar, case, entity, org, and signal views
+
+## Components
+
+- `web/` - Next.js frontend
+- `api/` - FastAPI public/internal endpoints
+- `worker/` - Celery tasks and schedules
+- `shared/` - domain logic shared across services
+- `postgres` - canonical and analytics storage
+- `redis` - cache + queue broker/backend
+
+## Scheduling
+
+The pipeline is orchestrated by Celery Beat (incremental ingest, ER, baselines, signals, coverage refresh, maintenance).
+
+## Design Rules
+
+- Deterministic detection only
+- Explainability over opaque scoring
+- Source-traceable evidence paths
+- Privacy safeguards by default

--- a/docs/wiki/Contributing-and-Governance.md
+++ b/docs/wiki/Contributing-and-Governance.md
@@ -1,0 +1,28 @@
+# Contributing and Governance
+
+## Governance Baseline
+
+- License: AGPL-3.0
+- Code of Conduct: Contributor Covenant 2.1
+- Security policy with responsible disclosure guidance
+- Issue/PR templates for consistency and triage
+
+## Contribution Flow
+
+1. Open an issue (bug, feature, or connector proposal)
+2. Create focused branch and implement deterministic changes
+3. Add/update tests and docs
+4. Open PR with verification evidence
+
+## Security and Privacy
+
+- Never commit secrets or real tokens
+- Preserve LGPD safeguards (no raw CPF persistence)
+- Report vulnerabilities through private channels per `SECURITY.md`
+
+## Key Docs
+
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `CODE_OF_CONDUCT.md`
+- `CLAUDE.md`

--- a/docs/wiki/Current-Status.md
+++ b/docs/wiki/Current-Status.md
@@ -1,0 +1,31 @@
+# Current Status
+
+Last updated: 2026-03-03
+
+## Product Scope
+
+- Public read-only web experience (no login required)
+- FastAPI API + Celery workers + PostgreSQL + Next.js
+- 10 connector modules ingesting 11 public source streams
+- 10 deterministic typology detectors (T01-T10)
+
+## Engineering Status
+
+- CI enabled and passing on `main`
+- OSS governance baseline completed:
+  - AGPL-3.0 license
+  - Contributor covenant code of conduct
+  - Contributing and security policies
+  - Issue and PR templates
+  - Contributor guidance for Claude Code
+
+## Operational Status
+
+- Full local stack available with Docker Compose
+- Scheduled processing pipeline configured via Celery Beat
+- Optional LLM explanation layer with deterministic fallback
+
+## Known Limits
+
+- Some data sources require tokens and/or large local datasets
+- Wiki git endpoint may require manual first-page initialization in GitHub UI before direct `.wiki.git` sync

--- a/docs/wiki/Data-Sources.md
+++ b/docs/wiki/Data-Sources.md
@@ -1,0 +1,24 @@
+# Data Sources
+
+## Source Inventory
+
+| Source | Access | Connector |
+|---|---|---|
+| Portal da Transparencia (sancoes + despesas + emendas + transferencias) | Token | `portal_transparencia` |
+| PNCP | Public | `pncp` |
+| Compras.gov.br | Public | `compras_gov` |
+| ComprasNet contratos | Public | `comprasnet_contratos` |
+| TransfereGov | Public | `transferegov` |
+| Camara dos Deputados | Public | `camara` |
+| Senado Federal | Public | `senado` |
+| TSE eleitoral | Public bulk | `tse` |
+| Receita Federal CNPJ | Public bulk | `receita_cnpj` |
+| Querido Diario | Public | `querido_diario` |
+
+Together these connectors provide 11 public-source streams used by the platform.
+
+## Notes
+
+- Portal da Transparencia requires `PORTAL_TRANSPARENCIA_TOKEN`
+- TSE and Receita CNPJ connectors depend on local data directories due file size
+- All connectors must implement deterministic `fetch` and `normalize` behavior

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,0 +1,25 @@
+# FAQ
+
+## Is AuditorIA Gov a commercial product?
+
+No. It is an open-source public-interest project.
+
+## Does the platform "prove" corruption?
+
+No. It surfaces deterministic risk signals and evidence for investigation.
+
+## Is AI used for scoring?
+
+No. Detection and scoring are deterministic. Optional LLM usage is explanatory only.
+
+## Can I run it locally?
+
+Yes. The repository includes Docker Compose and setup instructions.
+
+## Which data sources need credentials?
+
+Portal da Transparencia jobs require a token. Most other sources are public.
+
+## Where should I propose a new data connector?
+
+Open an issue with the `new_connector` template.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,31 @@
+# AuditorIA Gov Wiki
+
+Welcome to the AuditorIA Gov project wiki.
+
+AuditorIA Gov is an open-source citizen auditing platform for Brazilian federal public data.
+
+## Start Here
+
+- [Current Status](./Current-Status)
+- [Roadmap](./Roadmap)
+- [Architecture](./Architecture)
+- [Data Sources](./Data-Sources)
+- [Typologies](./Typologies)
+- [Runbook (Local + Pipeline)](./Runbook)
+- [Contributing and Governance](./Contributing-and-Governance)
+- [FAQ](./FAQ)
+
+## Core Principles
+
+- Deterministic risk detection (no black-box scoring)
+- Reproducible evidence for each signal
+- LGPD-by-design handling of sensitive identifiers
+- Public-interest mission with AGPL-3.0 license
+
+## Canonical Repository Docs
+
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `CLAUDE.md`

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,9 @@
+# Wiki Source Files
+
+This folder stores versioned source content for the GitHub Wiki.
+
+- Primary entry page: `Home.md`
+- Keep page names compatible with GitHub Wiki page URLs
+- Update these files through PRs so wiki changes are reviewed
+
+If the `.wiki.git` endpoint is unavailable, pages can be copied manually into the GitHub Wiki UI.

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+## Near-Term (Q1-Q2 2026)
+
+- Expand source robustness and retry telemetry
+- Increase typology coverage quality metrics and explainability
+- Improve public investigation UX and cross-entity navigation
+- Harden run observability and data freshness dashboards
+
+## Mid-Term
+
+- Add more government data connectors with deterministic normalization
+- Improve quality scoring and provenance visualization
+- Expand reproducibility artifacts for journalistic workflows
+
+## Long-Term
+
+- Multi-country portability of ingestion + typology engine
+- Community-maintained detector packs
+- Better civic newsroom collaboration workflows
+
+## Maintenance Priorities
+
+- Keep CI green
+- Preserve deterministic behavior and reproducible outputs
+- Enforce no-secrets and LGPD protections in contribution flow

--- a/docs/wiki/Runbook.md
+++ b/docs/wiki/Runbook.md
@@ -1,0 +1,38 @@
+# Runbook
+
+## Local Setup
+
+```bash
+git clone https://github.com/claudioemmanuel/auditoria-gov.git
+cd auditoria-gov
+cp .env.example .env
+docker compose up --build
+docker compose run --rm api alembic -c api/alembic.ini upgrade head
+```
+
+## Pipeline Trigger (Manual)
+
+```bash
+curl -X POST http://localhost:8000/internal/ingest/all
+curl -X POST http://localhost:8000/internal/er/run
+curl -X POST http://localhost:8000/internal/baselines/run
+curl -X POST http://localhost:8000/internal/signals/run
+curl -X POST http://localhost:8000/internal/coverage/update
+```
+
+## Verification
+
+```bash
+uv sync --extra test
+uv run --extra test pytest -q
+cd web && npm ci && npm run build
+```
+
+## Critical Environment Variables
+
+- `DATABASE_URL`
+- `REDIS_URL`
+- `PORTAL_TRANSPARENCIA_TOKEN`
+- `CPF_HASH_SALT`
+- `CELERY_BROKER_URL`
+- `CELERY_RESULT_BACKEND`

--- a/docs/wiki/Typologies.md
+++ b/docs/wiki/Typologies.md
@@ -1,0 +1,23 @@
+# Typologies
+
+The typology engine runs deterministic detectors registered in `shared/typologies/registry.py`.
+
+| Code | Typology |
+|---|---|
+| T01 | Supplier concentration |
+| T02 | Low competition |
+| T03 | Expense splitting |
+| T04 | Parliamentary amendment outlier |
+| T05 | Price outlier |
+| T06 | Shell company proxy |
+| T07 | Cartel network |
+| T08 | Sanctions mismatch |
+| T09 | Ghost payroll proxy |
+| T10 | Outsourcing + parallel payroll |
+
+## Detector Quality Expectations
+
+- Numeric factors and transparent thresholds
+- Reproducible evidence linked to raw/canonical records
+- Test coverage for minimum-detectable scenarios
+- Deterministic outputs for the same input data


### PR DESCRIPTION
## Summary
- add versioned wiki source pages under docs/wiki
- add wiki reference section in README
- include roadmap, current status, architecture, data sources, typologies, runbook, governance, and FAQ pages

## Verification
- docs-only changes
- manual review of links and page naming compatibility for GitHub Wiki